### PR TITLE
feat: Remove Bots from the Contributors list

### DIFF
--- a/layouts/shortcodes/collaborators.html
+++ b/layouts/shortcodes/collaborators.html
@@ -24,6 +24,7 @@
 
 <div class="contributor-box">
 {{ range $.Site.Data.collaborators }}
+{{ if not (in .login "[bot]") }}
 <span class="contributor-item">
     <figure>
         <a href="{{.html_url}}">
@@ -34,5 +35,6 @@
         </a>
     </figure>
 </span>
+{{ end }}
 {{ end }}
 </div>


### PR DESCRIPTION
Closes #9.

This removes everyone with `[bot]` in their login name. Might have to adjust that if we use other bots, but `dependabot[bot]` is now removed.