### PR TITLE
Change Docker Hub link to a public URL

### DIFF
--- a/content/docs/quickstart.md
+++ b/content/docs/quickstart.md
@@ -31,7 +31,7 @@ You can choose between downloading a zip file of Owncast, or using Docker.
 
 ### Use a Docker image
 
-1. Pull the `latest` version [from Dockerhub](https://hub.docker.com/repository/registry-1.docker.io/gabekangas/owncast/tags?page=1): `docker pull gabekangas/owncast:latest`.
+1. Pull the `latest` version [from Dockerhub](https://hub.docker.com/r/gabekangas/owncast/tags): `docker pull gabekangas/owncast:latest`.
 1. Run `docker run -p 8080:8080 -p 1935:1935 -it gabekangas/owncast:latest` to start the service.
 
 


### PR DESCRIPTION
The current one takes me to a login page, and seems a bit unusual for Docker Hub.