### PR TITLE
Adding missing semicolon which breaks this config for those attemptin…

### DIFF
--- a/content/docs/sslproxies/nginx.md
+++ b/content/docs/sslproxies/nginx.md
@@ -29,7 +29,7 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
-        proxy_pass http://127.0.0.1:8080
+        proxy_pass http://127.0.0.1:8080;
         
         listen 443 ssl;
         ssl_certificate /etc/letsencrypt/live/yourdomain.com/fullchain.pem;


### PR DESCRIPTION
…g to cut-and-paste.

Also, I had to add

```
map $connection_upgrade {
  default upgrade;
  ''      close;        
}
```
 
as documented [here](https://nginx.org/en/docs/http/websocket.html) or 
```
proxy_set_header Connection $connection_upgrade;
```
would cause the config to fail `sudo nginx -t`.