### PR TITLE
Document what Apache modules are required

### DIFF
--- a/content/docs/sslproxies/apache.md
+++ b/content/docs/sslproxies/apache.md
@@ -9,6 +9,12 @@ type: subpages
 
 Apache requires the most boilerplate configuration, but if you're already using Apache as a web server you can [configure it as a reverse proxy](https://httpd.apache.org/docs/2.4/howto/reverse_proxy.html) in front of your Owncast server to enable SSL.
 
+Ensure required Apache modules are enabled using the `a2enmod` command.
+
+```
+$ sudo a2enmod proxy proxy_http proxy_wstunnel ssl
+```
+
 {{< highlight ApacheConf >}}
 <VirtualHost *:80>
         ServerName live.example.com


### PR DESCRIPTION
`proxy_wstunnel` isn't commonly enabled, so should be mention here to ensure the config works.

Apache will complain otherwise

```
AH01144: No protocol handler was valid for the URL /entry (scheme 'ws'). If you are using a DSO version of mod_proxy, make sure the proxy submodules are included in the configuration using LoadModule.
```