### PR TITLE
Support ARM64 (armv8, aarch64) in quickinstall

### DIFF
--- a/static/install.sh
+++ b/static/install.sh
@@ -132,6 +132,10 @@ main () {
         FFMPEG_ARCH="linux-arm"
         OWNCAST_ARCH="arm7"
         ;;
+      aarch64)
+        FFMPEG_ARCH="linux-arm64"
+        OWNCAST_ARCH="arm64"
+        ;;
       *)
         errorAndExit "Unsupported CPU architecture $(uname -m)"
         ;;


### PR DESCRIPTION
Support for building for aarch64 was added in https://github.com/owncast/owncast/issues/1053 and confirmed in https://github.com/owncast/owncast/issues/1156. Installing it manually or via site.js works as expected on an aarch64 vps, in fact.

The quick installer, though, hasn't been updated to support this architecture and would fail with:
`ERROR: Unsupported CPU architecture aarch64Your Owncast installation did not complete successfully.`

This PR adds a case for aarch64, allowing the installer to execute successfully on it:

```
Created directory  [✓]
Downloaded Owncast v0.0.8 for linux  [✓]  

Success! Run owncast by changing to the owncast directory and run ./owncast.
The default port is 8080 and the default streaming key is abc123.
Visit https://owncast.online/docs/configuration/ to learn how to configure your new Owncast server.
```
and 

```
INFO[2021-08-28T07:41:11Z] Owncast v0.0.8-linux-arm64 (f5a045dedc7d60e58e1c22b8f6472007738f0d6e) 
INFO[2021-08-28T07:41:12Z] Video transcoder started using x264 with 1 stream variants. 
INFO[2021-08-28T07:41:12Z] RTMP is accepting inbound streams on port 1935. 
INFO[2021-08-28T07:41:12Z] Web server is listening on IP 0.0.0.0 port 8080. 
INFO[2021-08-28T07:41:12Z] The web admin interface is available at /admin. 
```