### PR TITLE
Typo

### DIFF
--- a/content/quickstart/manual.md
+++ b/content/quickstart/manual.md
@@ -13,4 +13,4 @@ type: subpages
 1. Make a directory to run the service from, and download a release from https://github.com/owncast/owncast/releases into that directory.
 1. Unzip the release.
 1. Run `./owncast` to start the service.
-1. Visit the admin at `/admin` to configure your server using the usernmae `admin` and the default stream key as the password, `abc123`.
+1. Visit the admin at `/admin` to configure your server using the username `admin` and the default stream key as the password, `abc123`.


### PR DESCRIPTION
Just noticed a small typo, 'usernmae' instead of 'username'.