### PR TITLE
Add display name derivation via reverse proxy chapter

### DIFF
--- a/content/docs/sslproxies/_index.md
+++ b/content/docs/sslproxies/_index.md
@@ -29,6 +29,10 @@ While not required, most people will want to support SSL on a public Owncast ser
 
 You can use any method you like to add SSL support but there are some popular options we've seen work well with people. If you have any specific questions or would like to make suggestions on configurations or other setups [let us know](/contact).
 
+## Inherit display name from reverse proxy
+
+Owncast usually assigns a random display name when new users are joining the chat. Upstream reverse proxies can influence this behavior by setting a `X-Forwarded-User` HTTP header. This header will be used instead of a random name to derive a user's display name. A user will still be able to change it's own display name to any desired value.
+
 ## Suggested
 
 If you have no requirement to use other options else it is suggested you install [Caddy](caddy/) as it can be installed quickly and easily.


### PR DESCRIPTION
This MR is the documentation counterpart of https://github.com/owncast/owncast/pull/1633. It documents how upstream HTTP reverse proxies can influence the default chat display name via HTTP header instead of fully relying on random name assignment.