### PR TITLE
Caddy directions changed for apt

### DIFF
--- a/content/docs/sslproxies/caddy.md
+++ b/content/docs/sslproxies/caddy.md
@@ -25,7 +25,7 @@ Depending on your system there may be different options on installing. Using APT
   Installing this package automatically starts and runs Caddy for you as a systemd service so it will automatically run Caddy each time you start your machine.
 {{< highlight bash >}}
 sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https
-curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo tee /etc/apt/trusted.gpg.d/caddy-stable.asc
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
 curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
 sudo apt update
 sudo apt install caddy


### PR DESCRIPTION
The caddy install instructions were failing in the Owncast docs. I used the directions from the caddy website successfully, so I updated the docs to reflect the directions on the caddy website.