### PR TITLE
add upgrade checks for the installation script

### DIFF
--- a/.github/workflows/test-install-script.yml
+++ b/.github/workflows/test-install-script.yml
@@ -33,7 +33,7 @@ jobs:
         run: static/install.sh
 
   debian:
-    name: On Debian/Ubuntu
+    name: Install on Debian/Ubuntu
     strategy:
       matrix:
         images:
@@ -56,7 +56,7 @@ jobs:
         run: static/install.sh
 
   arch:
-    name: On Arch
+    name: Install on Arch
     strategy:
       matrix:
         images:
@@ -74,7 +74,7 @@ jobs:
         run: static/install.sh
 
   rhel:
-    name: On RHEL/Fedora
+    name: Install on RHEL/Fedora
     strategy:
       matrix:
         images:
@@ -94,7 +94,7 @@ jobs:
         run: static/install.sh
 
   opensuse:
-    name: On OpenSUSE
+    name: Install on OpenSUSE
     strategy:
       matrix:
         images:

--- a/.github/workflows/test-install-script.yml
+++ b/.github/workflows/test-install-script.yml
@@ -10,11 +10,30 @@ on:
   pull_request:
     branches:
       - master
+      - v0.1.0
     paths:
       - 'static/install.sh'
 
 jobs:
+  upgrade:
+    name: Upgrade on Ubuntu from
+    strategy:
+      matrix:
+        old_version: [0.0.7, 0.0.8, 0.0.9, 0.0.10, 0.0.11, 0.0.12]
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/ubuntu:22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install needed packages
+        run: apt update && apt install -y curl unzip procps
+      - name: Install old version of Owncast
+        run: OWNCAST_VERSION=${{ matrix.old_version }} static/install.sh
+      - name: Upgrade to the latest version of Owncast
+        run: static/install.sh
+
   debian:
+    name: On Debian/Ubuntu
     strategy:
       matrix:
         images:
@@ -37,6 +56,7 @@ jobs:
         run: static/install.sh
 
   arch:
+    name: On Arch
     strategy:
       matrix:
         images:
@@ -54,6 +74,7 @@ jobs:
         run: static/install.sh
 
   rhel:
+    name: On RHEL/Fedora
     strategy:
       matrix:
         images:
@@ -73,6 +94,7 @@ jobs:
         run: static/install.sh
 
   opensuse:
+    name: On OpenSUSE
     strategy:
       matrix:
         images:

--- a/.github/workflows/test-install-script.yml
+++ b/.github/workflows/test-install-script.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: docker.io/ubuntu:22.04
+    env:
+      OWNCAST_BACKUP_DIRECTORY: tmpbk
     steps:
       - uses: actions/checkout@v3
       - name: Install needed packages
@@ -31,6 +33,8 @@ jobs:
         run: OWNCAST_VERSION=${{ matrix.old_version }} static/install.sh
       - name: Upgrade to the latest version of Owncast
         run: static/install.sh
+      - name: Check backup file
+        run: ls -A owncast/${OWNCAST_BACKUP_DIRECTORY}/*.tar.gz
 
   debian:
     name: Install on Debian/Ubuntu

--- a/.github/workflows/test-install-script.yml
+++ b/.github/workflows/test-install-script.yml
@@ -31,10 +31,14 @@ jobs:
         run: apt update && apt install -y curl unzip procps
       - name: Install old version of Owncast
         run: OWNCAST_VERSION=${{ matrix.old_version }} static/install.sh
+      - name: Initialize Owncast
+        run: cd owncast && timeout 5 ./owncast || true
       - name: Upgrade to the latest version of Owncast
         run: static/install.sh
-      - name: Check backup file
-        run: ls -A owncast/${OWNCAST_BACKUP_DIRECTORY}/*.tar.gz
+      - name: Check backup file is created
+        run: ls -lAH owncast/data owncast/${OWNCAST_BACKUP_DIRECTORY}/*.tar.gz
+      - name: Check backup has the expected content
+        run: tar -tf owncast/${OWNCAST_BACKUP_DIRECTORY}/*.tar.gz --wildcards '*/data/owncast\.db*' 
 
   debian:
     name: Install on Debian/Ubuntu

--- a/static/install.sh
+++ b/static/install.sh
@@ -101,7 +101,7 @@ backupInstall() {
   tar zcf ${BACKUP_FILE} backup & >> /dev/null
   spinner $!
   popd >> /dev/null
-  mv ${BACKUP_STAGING}/${BACKUP_FILE} backup/
+  mv ${BACKUP_STAGING}/${BACKUP_FILE} ${BACKUP_DIR}/
   
   rm -rf ${BACKUP_STAGING}
   printf "${BLUE}Backed up${NC} your files before upgrading to v${OWNCAST_VERSION}  [${GREEN}✓${NC}]\n"

--- a/static/install.sh
+++ b/static/install.sh
@@ -189,8 +189,7 @@ main () {
   rm "$OWNCAST_TARGET_FILE"
 
   # Check for ffmpeg
-  if ! command -v ffmpeg &> /dev/null
-  then
+  if ! [[ -x "$(command -v ffmpeg)" || -x "$(command -v ${OWNCAST_INSTALL_DIRECTORY}/ffmpeg)" ]]; then
     # Download ffmpeg
     printf "${BLUE}Downloading${NC} ffmpeg v${FFMPEG_VERSION} "
     curl -s -L ${FFMPEG_DOWNLOAD_URL} --output "${FFMPEG_TARGET_FILE}" &

--- a/static/install.sh
+++ b/static/install.sh
@@ -94,7 +94,6 @@ backupInstall() {
 
   for i in "${FILE_LIST[@]}"
   do
-    : 
     cp -r ${FILE_LIST[@]} ${BACKUP_STAGING}/backup
   done
 
@@ -162,13 +161,13 @@ main () {
 
   # If the install directory exists already then cd into it and upgrade
   if [[ -d "$OWNCAST_INSTALL_DIRECTORY" && -x "$OWNCAST_INSTALL_DIRECTORY/owncast" ]]; then
-    printf "${BLUE}Existing install found${NC} in ${OWNCAST_INSTALL_DIRECTORY}.  Will update it to v${OWNCAST_VERSION}. If this is incorrect remove the directory and rerun the installer.\n"
+    printf "${BLUE}Existing install found${NC} in ${OWNCAST_INSTALL_DIRECTORY}. Will update it to v${OWNCAST_VERSION}. If this is incorrect remove the directory and rerun the installer.\n"
     cd $OWNCAST_INSTALL_DIRECTORY
     OWNCAST_INSTALL_DIRECTORY="./"
     backupInstall
   # If the owncast binary exists then upgrade
   elif [ -x ./owncast ]; then
-    printf "${BLUE}Existing install found${NC} in this directory.  Will update it to v${OWNCAST_VERSION}. If this is incorrect remove the directory and rerun the installer.\n"
+    printf "${BLUE}Existing install found${NC} in this directory. Will update it to v${OWNCAST_VERSION}. If this is incorrect remove the directory and rerun the installer.\n"
     backupInstall
     OWNCAST_INSTALL_DIRECTORY="./"
   else

--- a/static/install.sh
+++ b/static/install.sh
@@ -107,7 +107,7 @@ backupInstall() {
   mv ${BACKUP_STAGING}/${BACKUP_FILE} ${OWNCAST_BACKUP_DIRECTORY}/
   
   rm -rf ${BACKUP_STAGING}
-  printf "${BLUE}Backed up${NC} your files before upgrading to v${OWNCAST_VERSION}  [${GREEN}✓${NC}]\n"
+  printf "${GREEN}Backed up${NC} your files before upgrading to v${OWNCAST_VERSION}  [${GREEN}✓${NC}]\n"
 }
 
 main () {

--- a/static/install.sh
+++ b/static/install.sh
@@ -14,6 +14,10 @@ if ! [ "${OWNCAST_INSTALL_DIRECTORY:-}" ]; then
   OWNCAST_INSTALL_DIRECTORY="$(pwd)/owncast"
 fi
 
+if ! [ "${OWNCAST_BACKUP_DIRECTORY:-}" ]; then
+  OWNCAST_BACKUP_DIRECTORY="${OWNCAST_INSTALL_DIRECTORY}/backup"
+fi
+
 INSTALL_TEMP_DIRECTORY="$(mktemp -d)"
 
 # Set up an exit handler so we can print a help message on failures.
@@ -80,17 +84,16 @@ requireTool() {
 backupInstall() {
   BACKUP_STAGING="$(mktemp -d)"
   mkdir ${BACKUP_STAGING}/backup
-  BACKUP_DIR="backup"
   TIMESTAMP=$(date +%s)
   BACKUP_FILE="${TIMESTAMP}-v${OWNCAST_VERSION}".tar.gz
-  printf "${BLUE}Backing up${NC} your files before upgrading to v${OWNCAST_VERSION}"
+  printf "${BLUE}Backing up${NC} your files to ${OWNCAST_BACKUP_DIRECTORY} before upgrading to v${OWNCAST_VERSION}"
 
   FILE_LIST=(
     "data/"
   )
 
   # Make backup directory if it doesn't exist
-  [[ -d $BACKUP_DIR ]] || mkdir $BACKUP_DIR
+  [[ -d $OWNCAST_BACKUP_DIRECTORY ]] || mkdir $OWNCAST_BACKUP_DIRECTORY
 
   for i in "${FILE_LIST[@]}"
   do
@@ -101,7 +104,7 @@ backupInstall() {
   tar zcf ${BACKUP_FILE} backup & >> /dev/null
   spinner $!
   popd >> /dev/null
-  mv ${BACKUP_STAGING}/${BACKUP_FILE} ${BACKUP_DIR}/
+  mv ${BACKUP_STAGING}/${BACKUP_FILE} ${OWNCAST_BACKUP_DIRECTORY}/
   
   rm -rf ${BACKUP_STAGING}
   printf "${BLUE}Backed up${NC} your files before upgrading to v${OWNCAST_VERSION}  [${GREEN}✓${NC}]\n"

--- a/static/install.sh
+++ b/static/install.sh
@@ -105,7 +105,7 @@ backupInstall() {
   spinner $!
   popd >> /dev/null
   mv ${BACKUP_STAGING}/${BACKUP_FILE} ${OWNCAST_BACKUP_DIRECTORY}/
-  
+
   rm -rf ${BACKUP_STAGING}
   printf "${GREEN}Backed up${NC} your files before upgrading to v${OWNCAST_VERSION}  [${GREEN}✓${NC}]\n"
 }


### PR DESCRIPTION
- run checks on v0.1.0 branch too
- test upgrading from versions >=0.0.7 to the latest Owncast version
- do not download ffmpeg if it already exists in the owncast directory
- make sure backup file [on CI with default Owncast configs for path of database] is created on upgrade and contains `owncast.db*`.