### PR TITLE
Add documentation for AWS ACL options

### DIFF
--- a/content/docs/storage/aws.md
+++ b/content/docs/storage/aws.md
@@ -17,7 +17,7 @@ Here's some example usage and pricing for AWS S3:
 
 https://s3.console.aws.amazon.com/s3
 
-Uncheck "Block all public access" since you want all files to be readable. Leave the rest of the default values.
+Uncheck "Block all public access" since you want all files to be readable. Check "ACLs Enabled" to allow a dedicated AWS user to access objects on this server. Leave the rest of the default values.
 
 ## Create an expiration policy
 

--- a/content/docs/storage/aws.md
+++ b/content/docs/storage/aws.md
@@ -17,7 +17,7 @@ Here's some example usage and pricing for AWS S3:
 
 https://s3.console.aws.amazon.com/s3
 
-Uncheck "Block all public access" since you want all files to be readable. Check "ACLs Enabled" to allow a dedicated AWS user to access objects on this server. Leave the rest of the default values.
+Uncheck "Block all public access" since you want all files to be readable. Check "ACLs Enabled" to allow non-owner AWS users to manage objects in the bucket. Leave the rest of the default values.
 
 ## Create an expiration policy
 


### PR DESCRIPTION
Hi Owncast team, 

I spent about an hour trying to debug my S3 configuration earlier and discovered that I had created a bucket with the ACLs disabled. I'm not sure if this is a default setting specific to my account or if other users might see this as well, but I've been able to recreate it during the S3 bucket creation process. The defaults that I see when creating an S3 bucket are attached in a screenshot below.

Since the docs state that the only necessary configuration change is to "Uncheck 'Block all public access'" I wanted to be sure that this important option would not be missed by future users as well.

Thanks! Happy to discuss further.

![image](https://user-images.githubusercontent.com/11223400/213018773-f8dff30e-bfcf-4bfa-8431-a14bfe1f9e57.png)
