### PR TITLE
Re-push prettier commits after rebase

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -20,9 +20,26 @@ jobs:
 
     - name: Prettify code
       uses: creyD/prettier_action@v3.1
+      continue-on-error: true
       with:
         # This part is also where you can pass other options, for example:
         prettier_options: --write **/*.{html,md,css,scss}
         only_changed: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    # The prettier step attempts to push automatically. However, it does no
+    # rebase before pushing, so if commits were pushed while prettier was
+    # running (which happens, e.g. due to automatic contributors.json update)
+    # the push fails. This step will re-attempt the push, but this time with
+    # a rebase.
+    # The `git restore` is necessary in case prettier changes code that
+    # isn't committed due to not being part of the current changes (see
+    # the `only_changed` option)
+    - name: Push with rebase
+      run: |
+        git restore .
+        git config user.email "actions@github.com"
+        git config user.name "GitHub Action"
+        git pull --rebase
+        git push


### PR DESCRIPTION
This adds an extra step to the `prettier` action that pushes any existing commits after rebasing. An example of this working can be seen [in this run on my fork](https://github.com/LBBO/owncast.github.io/actions/runs/3950413625/jobs/6762905703). Just in case the logs aren't publicly visible, here's a screenshot of the relevant section:

![image](https://user-images.githubusercontent.com/8076094/213222371-b7e61f2b-ad1f-4661-acfa-d3c32e99129c.png)

Fixes https://github.com/owncast/owncast/issues/2599