### PR TITLE
Fix non-coded iframe

### DIFF
--- a/content/docs/embed.md
+++ b/content/docs/embed.md
@@ -49,7 +49,7 @@ You can easily customize the styling of the embedded Owncast stream to match you
    ```
    Replace "path/to/stream-styles.css" with the actual path to your CSS file.
 
-3. **Apply Styles:** Customize the styles in your stream-styles.css file according to your preferences. You can target the <iframe> element using CSS selectors, as shown in the example below:
+3. **Apply Styles:** Customize the styles in your stream-styles.css file according to your preferences. You can target the `<iframe>` element using CSS selectors, as shown in the example below:
    ```css
     /* Customize the embedded stream container */
     iframe {


### PR DESCRIPTION
By not using back-ticks to "codify" the iframe tag, it caused hugo to render a blank iframe and consume/remove a bunch of text that came after it.

Comparison of before and after:
<img width="1728" alt="Screenshot 2023-10-09 at 6 21 07 AM" src="https://github.com/owncast/owncast.github.io/assets/5209474/9fd6d470-6e4d-43dd-9a9d-dce5f0fd5717">
