### PR TITLE
fix(development): fix URL of golangci-lint

### DIFF
--- a/content/development.md
+++ b/content/development.md
@@ -66,7 +66,7 @@ The backend of Owncast is written in Go. It operates as a web and API server, in
 
 ### Go Linting
 
-We use golangci-lint to lint our Go code. While optional, it is a useful tool to assist you in writing better Go code. You can install it from the [golangci-lint](https://golangci-lint.run/usage/install/#local-installation) website.
+We use golangci-lint to lint our Go code. While optional, it is a useful tool to assist you in writing better Go code. You can install it from the [golangci-lint](https://golangci-lint.run/welcome/install/#local-installation) website.
 
 ## Run a development stream
 


### PR DESCRIPTION
## Fix broken documentation link to golangci-lint
Fixes [#3633](https://github.com/owncast/owncast/issues/3633)

- [x] Change the broken golangci-lint link from `https://golangci-lint.run/usage/install/#local-installation` to `https://golangci-lint.run/welcome/install/#local-installation`.