### PR TITLE
docs: update dead HLS link

### DIFF
--- a/content/docs/video.md
+++ b/content/docs/video.md
@@ -27,7 +27,7 @@ Because Owncast uses the HLS standard, almost any video player can play your str
 
 ## How does an Owncast video stream work?
 
-Owncast takes your source stream and converts it to short, individual video segments. A list of these segments is supplied to your viewer's player and will read and play all the segments in order. This is using a specification called [HLS](https://developer.apple.com/documentation/http_live_streaming/understanding_the_http_live_streaming_architecture) or HTTP Live Streaming. You can optionally generate multiple different qualities of video to allow lower bandwidth options. This is called [Adaptive bitrate streaming](https://en.wikipedia.org/wiki/Adaptive_bitrate_streaming).
+Owncast takes your source stream and converts it to short, individual video segments. A list of these segments is supplied to your viewer's player and will read and play all the segments in order. This is using a specification called [HLS](https://developer.apple.com/documentation/http-live-streaming) or HTTP Live Streaming. You can optionally generate multiple different qualities of video to allow lower bandwidth options. This is called [Adaptive bitrate streaming](https://en.wikipedia.org/wiki/Adaptive_bitrate_streaming).
 
 This video from Jon Dahl is gives a very good overview of internet video, starting with _"what happens when you press play in your web browser?"_ and touching on every piece of the stack, backend and frontend. It translates very well to how Owncast works and is suggested if you want to learn more.
 


### PR DESCRIPTION
Fixes: https://github.com/owncast/owncast/issues/3580

Updated the HLS link to the new Apple Developer docs for HTTP Live Streaming
https://developer.apple.com/documentation/http-live-streaming