### PR TITLE
fix: broken jitsi website URL

### DIFF
--- a/content/docs/broadcasting/jitsi.md
+++ b/content/docs/broadcasting/jitsi.md
@@ -4,7 +4,7 @@ description: "Jitsi is an open source video conferencing provider."
 type: subpages
 ---
 
-[Jitsi](https://jit.org) is both a video conferencing provider and a software suite. It is open source and can be self-hosted. It is also available as a service at [meet.jit.si](https://meet.jit.si).
+[Jitsi](https://jitsi.org) is both a video conferencing provider and a software suite. It is open source and can be self-hosted. It is also available as a service at [meet.jit.si](https://meet.jit.si).
 
 1. Visit your Jitsi meeting page.
 2. Click on the three dots in the lower right.


### PR DESCRIPTION
fixes owncast/owncast#3571

The correct link is [jitsi.org](jitsi.org) instead of [jit.org](jit.org)