### PR TITLE
Add missing integrations endpoint api links

### DIFF
--- a/content/thirdparty/apis.md
+++ b/content/thirdparty/apis.md
@@ -12,16 +12,16 @@ type: subpages
 
 We currently support the following actions you can make via requests from your code.
 
-| Event                    |                                                                      Endpoint                                                                      |                      Scope |
-| :--------------------    | :------------------------------------------------------------------------------------------------------------------------------------------------: | -------------------------: |
-| System chat message      |               <a href="/api/latest/#tag/Integrations/paths/~1api~1integrations~1streamtitle/post">/api/integrations/chat/system</a>                | `CAN_SEND_SYSTEM_MESSAGES` |
-| Standard chat message    |                                                     <a href="">/api/integrations/chat/send</a>                                                     |        `CAN_SEND_MESSAGES` |
-| Chat action              |                <a href="/api/latest/#tag/Integrations/paths/~1api~1integrations~1chat~1user/post">/api/integrations/chat/action</a>                | `CAN_SEND_SYSTEM_MESSAGES` |
-| Remove chat message      | <a href="/api/latest/#tag/Integrations/paths/~1api~1integrations~1chat~1updatemessagevisibility/post">/api/integrations/chat/messagevisibility</a> |         `HAS_ADMIN_ACCESS` |
-| Get chat history         |                       <a href="/api/latest/#tag/Integrations/paths/~1api~1integrations~1chat/get">/api/integrations/chat</a>                       |         `HAS_ADMIN_ACCESS` |
-| Get connected clients    |                    <a href="/api/latest/#tag/Integrations/paths/~1api~1integrations~1clients/get">/api/integrations/clients</a>                    |         `HAS_ADMIN_ACCESS` |
-| Set stream title         |               <a href="/api/latest/#tag/Integrations/paths/~1api~1integrations~1streamtitle/post">/api/integrations/streamtitle</a>                |         `HAS_ADMIN_ACCESS` |
-| system message to client |                                  <a href="">/api/integrations/chat/system/client/{clientId}</a>                                                    | `CAN_SEND_SYSTEM_MESSAGES` |
+| Event                    |                                                                      Endpoint                                                                                |                      Scope |
+| :--------------------    | :----------------------------------------------------------------------------------------------------------------------------------------------------------: | -------------------------: |
+| System chat message      |               <a href="/api/latest/#tag/Integrations/paths/~1api~1integrations~1streamtitle/post">/api/integrations/chat/system</a>                          | `CAN_SEND_SYSTEM_MESSAGES` |
+| Standard chat message    |                 <a href="/api/latest/#tag/Integrations/paths/~1api~1integrations~1chat~1send/post">/api/integrations/chat/send</a>                           |        `CAN_SEND_MESSAGES` |
+| Chat action              |                <a href="/api/latest/#tag/Integrations/paths/~1api~1integrations~1chat~1user/post">/api/integrations/chat/action</a>                          | `CAN_SEND_SYSTEM_MESSAGES` |
+| Remove chat message      | <a href="/api/latest/#tag/Integrations/paths/~1api~1integrations~1chat~1updatemessagevisibility/post">/api/integrations/chat/messagevisibility</a>           |         `HAS_ADMIN_ACCESS` |
+| Get chat history         |                       <a href="/api/latest/#tag/Integrations/paths/~1api~1integrations~1chat/get">/api/integrations/chat</a>                                 |         `HAS_ADMIN_ACCESS` |
+| Get connected clients    |                    <a href="/api/latest/#tag/Integrations/paths/~1api~1integrations~1clients/get">/api/integrations/clients</a>                              |         `HAS_ADMIN_ACCESS` |
+| Set stream title         |               <a href="/api/latest/#tag/Integrations/paths/~1api~1integrations~1streamtitle/post">/api/integrations/streamtitle</a>                          |         `HAS_ADMIN_ACCESS` |
+| system message to client | <a href="/api/latest/#tag/Integrations/paths/~1api~1integrations~1chat~1system~1client~1{clientId}/post">/api/integrations/chat/system/client/{clientId}</a> | `CAN_SEND_SYSTEM_MESSAGES` |
 Visit the API documentation for each endpoint to learn more about what values are expected or will be returned.
 
 Your Owncast server will only accept actions from requests with a valid Access Token. Follow the below steps to create an access token.


### PR DESCRIPTION
See https://github.com/owncast/owncast/issues/3769#issuecomment-2148364980

Those 2 links had empty hrefs. Pointed them to the api docs.