### PR TITLE
Remove OpenMax and Raspberry Pi sections from docs/codecs.md

### DIFF
--- a/content/docs/codecs.md
+++ b/content/docs/codecs.md
@@ -35,14 +35,6 @@ toc: true
 
 If you have Intel integrated graphics you may be able to use it using [VA-API](#va-api).
 
-### Raspberry Pi
-
-**Note:** The most recent version of the Raspberry Pi OS has a bug with the OpenMax codec. Use the previous version of the OS [by downloading it](https://downloads.raspberrypi.org/raspios_full_armhf/images/raspios_full_armhf-2021-05-28/2021-05-07-raspios-buster-armhf-full.zip), unzipping it, and using the [Raspberry Pi Imager](https://www.raspberrypi.com/software/) to save it to your SD card for installation.
-
-Using that version of the Raspberry Pi operating system it's actually quite easy to get Owncast running in a hardware accelerated fashion. Raspberry Pi OS includes support for [OpenMax](#openmax) (OMX) out of the box and includes a version of `ffmpeg` that is built to support it.
-
-However, this seems to only be true for 32 bit operating systems on a Raspberry Pi, as [omx seems to be deprecated under 64 bit environments](https://github.com/raspberrypi/firmware/issues/1366#issuecomment-612902082).
-
 ### NVIDIA GPUs
 
 NVIDIA GPUs ship with an on-chip hardware encoder unit often referred to as NVENC. Separate from the CUDA cores, NVENC run encoding workloads without slowing the execution of graphics or CUDA workloads running at the same time.
@@ -78,14 +70,6 @@ Links:
 
 - [VA-API at Linux Reviews](https://linuxreviews.org/VAAPI)
 - [Intel Media Driver for VA-API](https://github.com/intel/media-driver/)
-
-### OpenMAX
-
-OpenMAX is a unified abstraction layer that allows access to hardware that otherwise requires vendor specific APIs. It will work out of the box on modern Raspberry Pi's running a recent version of the [Raspberry Pi OS](https://www.raspberrypi.org/documentation/installation/noobs.md) operating system.
-
-Verify your copy of ffmpeg has omx support by looking at the [ffmpeg](#ffmpeg) instructions below. If `h264_omx` is in the list you should be good to go.
-
-Note: OpenMAX support has unfortunately been disconnected with the Raspberry Pi OS. To get hardware accelerated encoding working on a Raspberry Pi it will require running an older 32 bit version of the operating system.
 
 ### NVIDIA Encoder (nvenc)
 


### PR DESCRIPTION
Removes the OpenMX and Raspberry Pi sections from `/contents/docs/codecs.md`, fixing [#3886 in owncast/owncast](https://github.com/owncast/owncast/issues/3866).