### PR TITLE
Update apache.md according to modern apache documentation

### DIFF
--- a/content/docs/sslproxies/apache.md
+++ b/content/docs/sslproxies/apache.md
@@ -7,22 +7,21 @@ images: []
 type: subpages
 ---
 
-Apache requires the most boilerplate configuration, but if you're already using Apache as a web server you can [configure it as a reverse proxy](https://httpd.apache.org/docs/2.4/howto/reverse_proxy.html) in front of your Owncast server to enable SSL.
+If you're already using Apache as a web server you can [configure it as a reverse proxy](https://httpd.apache.org/docs/2.4/howto/reverse_proxy.html) in front of your Owncast server to enable SSL.
+The following configuration example requires Apache >= 2.4.47.
 
 Ensure required Apache modules are enabled using the `a2enmod` command.
 
 ```
-$ sudo a2enmod proxy proxy_http proxy_wstunnel ssl
+$ sudo a2enmod proxy proxy_http ssl
 ```
 
 {{< highlight ApacheConf >}}
-<VirtualHost \*:80>
-ServerName live.example.com
-ServerAdmin admin@example.com
+<VirtualHost *:80>
+        ServerName live.example.com
+        ServerAdmin admin@example.com
 
-        RewriteEngine on
-        RewriteCond %{SERVER_NAME} =live.example.com
-        RewriteRule ^ https://%{SERVER_NAME}%{REQUEST_URI} [END,NE,R=permanent]
+        Redirect permanent / https://live.example.com
 
 </VirtualHost>
 
@@ -37,24 +36,11 @@ ServerAdmin admin@example.com
         ProxyPreserveHost   On
         AllowEncodedSlashes NoDecode
 
-        <Proxy *>
-          Order deny,allow
-          Allow from all
-        </Proxy>
-
-        ProxyPass        / http://localhost:8080/
+        ProxyPass        / http://localhost:8080/ upgrade=websocket
         ProxyPassReverse / http://localhost:8080/
 
         RequestHeader    set X-Forwarded-Proto "https"
         RequestHeader    set X-Forwarded-Port "443"
-
-        # setup the proxy to forward websocket requests properly
-        # (note: this proxy automatically converts the secure websocket (wss)
-        # to a normal websocket and vice versa.
-        RewriteEngine On
-        RewriteCond %{HTTP:UPGRADE} ^WebSocket$           [NC,OR]
-        RewriteCond %{HTTP:CONNECTION} ^Upgrade$          [NC]
-        RewriteRule .* ws://127.0.0.1:8080%{REQUEST_URI}  [P,QSA,L]
 
         SSLCertificateFile /path/to/fullchain.pem
         SSLCertificateKeyFile /path/to/privkey.pem


### PR DESCRIPTION
Since the release of Apache 2.4.47 (released in April 2021) a lot has changed in regard to Apache's handling of websockets. mod_proxy_wstunnel is not needed anymore, neither is mod_rewrite. Order and Allow directives have also been for long marked as deprecated and are hence removed here.

See also:
- https://httpd.apache.org/docs/2.4/mod/mod_proxy.html#wsupgrade
-  https://httpd.apache.org/docs/2.4/mod/mod_proxy.html#protoupgrade