### PR TITLE
Add official GitHub star count button above the fold

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -7,6 +7,7 @@
     </figure>
 
     <div class="intro col-lg-7 col-md-16">
+      <a class="github-button" href="https://github.com/owncast/owncast" data-color-scheme="no-preference: dark; light: dark; dark: dark;" data-size="large" data-show-count="true" aria-label="Star owncast/owncast on GitHub">Star</a>
       <p class="lead">Owncast is a free and open source live video and web chat server for use with existing popular broadcasting software.</p>
       <a class="btn btn-primary btn-lg px-4 mb-2" href="{{ "quickstart/" | absURL }}" role="button">Get started</a>
     </div>
@@ -30,6 +31,8 @@
       }
     }
   </script>
+  <!-- GitHub Star Button -->
+<script async defer src="https://buttons.github.io/buttons.js"></script>
 </section>
 
 <!-- 4 key points section -->


### PR DESCRIPTION
fix #4280 add official GitHub star count button in hero section, which is above the fold