### PR TITLE
docs: clarify admin password vs stream key authentication

### DIFF
--- a/content/docs/configuration.md
+++ b/content/docs/configuration.md
@@ -8,7 +8,15 @@ weight: 100
 toc: true
 ---
 
-Configuration is done through the Owncast administration page located on your server under `/admin`. The login username is `admin` and the password is your stream key, the default being `abc123`.
+Configuration is done through the Owncast administration page located on your server under `/admin`. 
+
+**Admin Authentication:**
+- **Username:** `admin`  
+- **Password:** your admin password (not your stream key)
+
+The default admin password is `abc123`.
+
+**Note:** Your stream key is only used by your streaming software to publish video; it is not your admin password.
 
 **It's highly encouraged to change both your stream key and your admin passwords immediately after installation by visiting `/admin/config/server/`**
 

--- a/content/quickstart/configure.md
+++ b/content/quickstart/configure.md
@@ -12,7 +12,15 @@ type: subpages
 
 While Owncast will work for you out of the box, there are things most people will want to customize after getting it up and running.
 
-Configuration is done through the Owncast administration page located on your server under `/admin`. The login username is `admin` and the password is your stream key, the default being `abc123`.
+Configuration is done through the Owncast administration page located on your server under `/admin`. 
+
+**Admin Authentication:**
+- **Username:** `admin`  
+- **Password:** your admin password (not your stream key)
+
+The default admin password is `abc123`.
+
+**Note:** Your stream key is only used by your streaming software to publish video; it is not your admin password.
 
 Some common items many people would want to update after installing Owncast are:
 

--- a/data/openapi.yaml
+++ b/data/openapi.yaml
@@ -112,7 +112,7 @@ components:
     AdminBasicAuth:
       type: http
       scheme: basic
-      description: The username for admin basic auth is `admin` and the password is the stream key.
+      description: The username for admin basic auth is `admin` and the password is your admin password (not your stream key). The default password is `abc123`.
 
   responses:
     BasicResponse:


### PR DESCRIPTION
## Description
This PR fixes documentation confusion around admin authentication by clarifying that the admin password is separate from the stream key.

## Changes Made
- **Configuration Guide**: Updated `content/docs/configuration.md` to clarify admin vs stream authentication
- **Quickstart Guide**: Updated `content/quickstart/configure.md` with correct authentication info
- **OpenAPI Spec**: Updated `data/openapi.yaml` to properly document admin authentication and default password

## Related Issue
Addresses [owncast/owncast#4405](https://github.com/owncast/owncast/issues/4405) (documentation clarification portion)

