### PR TITLE
Correct alternate text for Digital Ocean logo image

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -121,7 +121,7 @@
     </li>
     <li>
       <a href="https://digitalocean.com?utm_medium=opensource&utm_source=owncast">
-        <img src="/images/sponsors/digitalocean.svg" alt="rocket chat"/>
+        <img src="/images/sponsors/digitalocean.svg" alt="digial ocean"/>
       </a>
     </li>
   </ul>


### PR DESCRIPTION
Just noticed alternate text for Digital Ocean logo image is incorrect. 

fixes https://github.com/owncast/owncast/issues/4476