### PR TITLE
make the year dynamic in Hacktoberfest documentation

### DIFF
--- a/content/hacktoberfest.md
+++ b/content/hacktoberfest.md
@@ -22,18 +22,13 @@ For the past 10 years, thousands of people—coders and non-coders alike—have 
 
 ## What is Owncast?
 
-Owncast is a single-user live streaming server with chat features that allows you to run your own live stream. It's volunteer run, donation funded, and 100% free and open source software that exists for the community. [See some examples in use](https://directory.owncast.online). If you're curious what some of the users have to say about the software and what they're doing with it, [here's some discussing why they like it](https://videos.owncast.online/v/GbUWuPQzFvN88SGuihfrS9).
+Owncast is a single-user live streaming server with chat features that allows you to run your own live stream. It's volunteer run, donation funded, and 100% free and open source software that exists for the community. [See some examples in use](https://owncast.directory). If you're curious what some of the users have to say about the software and what they're doing with it, [here's some discussing why they like it](https://videos.owncast.online/v/GbUWuPQzFvN88SGuihfrS9).
 
 ## What do you receive by contributing to Owncast during Hacktoberfest?
 
 - You’ll unlock a digital badge when you register for Hacktoberfest, and level it up with each of your four pull/merge requests accepted during Hacktoberfest.
-- Quality contributions[^1] to Owncast will receive an **Owncast t-shirt**. If you feel like you have qualified for a shirt, please [register for your t-shirt here!](https://gabekangas.typeform.com/to/Wfx9UHVZ).
 - You get added to the Owncast list of contributors on the [Owncast website](https://owncast.online), [GitHub repository](https://github.com/owncast/owncast) **and** the contributors thank-you video on [Owncast TV](https://watch.owncast.online).
 - You take part in a **global event**, contribute to **a cool project**, and be a part of the **open source community**.
-
-<div style="display: flex; flex-direction: row; justify-content: center">
-    {{< figure src="../images/owncast-tshirt.png" caption="Owncast<br/>Contributor t-shirt" height="200px" >}}
-</div>
 
 ## Code Contributions
 
@@ -68,7 +63,7 @@ The Owncast project is always looking for ways to get in front of more people an
 
 ## Usage Contributions
 
-If you've been thinking about trying Owncast for the first time but haven't found the right time to be inspired to try it out, **this is your chance**. If you spin up a new public Owncast server and list it on the [Owncast Directory](https://directory.owncast.online) during Hacktoberfest, you'll receive a t-shirt from us.
+If you've been thinking about trying Owncast for the first time but haven't found the right time to be inspired to try it out, **this is your chance**. If you spin up a new public Owncast server and list it on the [Owncast Directory](https://owncast.directory) during Hacktoberfest, you'll receive a t-shirt from us.
 
 ## Where to Begin
 
@@ -80,7 +75,3 @@ If you've been thinking about trying Owncast for the first time but haven't foun
 - [Join our chat](https://owncast.rocket.chat) and introduce yourself.
 
 See you soon!
-
----
-
-[^1]: A quality contribution is generally seen as that needed to be completed, fixing a bug that was reported, writing useful documentation, creating content around Owncast, or performing some piece of work within the Owncast organization that previously was determined to be needed. Coming up with your own arbitrary ideas, fixing typos, or making up changes just for the sake of getting PRs merged in are not seen as a quality contribution.

--- a/layouts/shortcodes/hacktoberfest.html
+++ b/layouts/shortcodes/hacktoberfest.html
@@ -1,7 +1,5 @@
 {{ $type := .Get "type" | default "year" }}
 {{ $currentYear := now.Year }}
-
-
 {{ if eq $type "image" }}
    <a href="https://hacktoberfest.com">
        <img src="../images/hacktoberfest.png" alt="hacktoberfest {{ $currentYear }} logo" width="80%"/>


### PR DESCRIPTION
It's troublesome to remember to update the text manually. I've updated the code so that the year would always display the current year using `{{ .Now.Year }}`