### PR TITLE
Remove Qnap option in Quickstart

### DIFF
--- a/layouts/wizard/list.html
+++ b/layouts/wizard/list.html
@@ -62,7 +62,7 @@ THE SOFTWARE.
         background: #827bff;
       }
 	   .restartButton {
-        background: lightgrey;
+        background: #6544e9;
         font-family: inherit;
         min-width: auto;
       }

--- a/static/wizardassets/data/quickstart_flow.json
+++ b/static/wizardassets/data/quickstart_flow.json
@@ -245,19 +245,6 @@
 										"id": 29
 									}
 								]
-							},
-							{
-								"name": "_decision",
-								"test": "string",
-								"if": "qnap",
-								"is_open": false,
-								"id": 30,
-								"children": [
-									{
-										"name": "https://qnapclub.eu/en/qpkg/1138",
-										"id": 31
-									}
-								]
 							}
 						]
 					}

--- a/static/wizardassets/data/quickstart_pages.json
+++ b/static/wizardassets/data/quickstart_pages.json
@@ -193,13 +193,6 @@
 						},
 						"type": "radio",
 						"value": "cloudron"
-					},
-					{
-						"text": {
-							"en": "I own a Qnap NAS"
-						},
-						"type": "radio",
-						"value": "qnap"
 					}
 				],
 				"required": true


### PR DESCRIPTION
Changelist:
- Remove Qnap option in https://owncast.online/quickstart/. You should see 2 options instead of 3 after Select "Other specific hardware or hosting environments".
- change Restart button color from light gray to purple as gray button gives the disabled/non-interactable look

closes https://github.com/owncast/owncast/issues/4234
links to https://github.com/owncast/owncast/issues/4233