### PR TITLE
Document Fediverse follow webhook

### DIFF
--- a/content/docs/social.md
+++ b/content/docs/social.md
@@ -82,6 +82,8 @@ By clicking the _Compose_ button in the admin header you can create a post to se
 
 If somebody **follows** you, **likes** a post you send out, or **shares** any of your posts while a stream is live it will display that these actions took place within the chat feed. This can be disabled under the social settings.
 
+Fediverse follow events are also available to third-party integrations through [webhooks](/thirdparty/webhooks/#fediverse_engagement_follow).
+
 <center>
     <figure>
   <img src="/docs/img/fediverse.svg" width="30%" id="learn-more" />

--- a/content/thirdparty/webhooks.md
+++ b/content/thirdparty/webhooks.md
@@ -23,6 +23,7 @@ The following is a list of events you can get notified about.
 | [STREAM_STOPPED](#stream_stopped)       | an incoming RTMP stream disconnects (e.g. OBS stops)                                           |
 | [STREAM_TITLE_UPDATED](#stream_title_updated)       | the title of the stream is updated  |
 | [VISIBILITY-UPDATE](#visibility-update) | a previously sent chat message becomes visible/invisible (set by an Administrator/Moderator)   |
+| [FEDIVERSE_ENGAGEMENT_FOLLOW](#fediverse_engagement_follow) | a Fediverse user follows your server                                             |
 
 
 ### How to accept webhooks
@@ -205,6 +206,26 @@ Note: the field `user` in the chat was introduced with `v0.0.8`. Before `v0.0.8`
 }
 ```
 - `MessageIDs` is a list of IDs of messages that had their visibility changed.
+
+#### FEDIVERSE_ENGAGEMENT_FOLLOW
+
+```json
+{
+    "eventData": {
+        "timestamp": "2026-04-13T19:17:12.528099886Z",
+        "id": "AqilY4hDR",
+        "name": "Test Follower",
+        "username": "testfollower@fake-mastodon.example.com",
+        "image": "https://fake-mastodon.example.com/avatars/testfollower.png"
+    },
+    "type": "FEDIVERSE_ENGAGEMENT_FOLLOW"
+}
+```
+
+- `eventData.id` is an Owncast-generated webhook event ID. It is not the Fediverse actor ID or follow request ID.
+- `eventData.name` is the display name of the follower.
+- `eventData.username` is the full `user@domain` handle.
+- `eventData.image` is the URL to the follower's avatar.
 
 ### clientId vs. user.id
 


### PR DESCRIPTION
## Summary

Document the `FEDIVERSE_ENGAGEMENT_FOLLOW` webhook payload.

## Motivation

Integrations can subscribe to Fediverse follow events, but the webhook docs did not list the event type or show the payload shape.

## Changes

- Add `FEDIVERSE_ENGAGEMENT_FOLLOW` to the webhook event table.
- Add a payload example and field notes for Fediverse follow webhook events.
- Link the social engagement docs to the webhook payload reference.

---
A similar PR will be made to the new site's repo!