### PR TITLE
docs: Remove Version Line in container.md

### DIFF
--- a/content/quickstart/container.md
+++ b/content/quickstart/container.md
@@ -15,7 +15,6 @@ toc: false
 Alternatively, you can create a `docker-compose.yml` file with the following contents:
 
 ```yaml
-version: "3"
 services:
   owncast:
     image: owncast/owncast:latest


### PR DESCRIPTION
This version line has been deprecated and throws a warning up everytime docker compose up -d is used, this just removes that line and should be good to go :) 