### PR TITLE
fix: change urls to "owncast.directory" from "directory.owncast.online"

### DIFF
--- a/content/docs/watching-on-tvs.md
+++ b/content/docs/watching-on-tvs.md
@@ -17,7 +17,7 @@ Any application that supports HLS video will play back an Owncast stream. Instal
 
 ## Browsing the directory
 
-If your application has _IPTV_ or _M3U_ support, you can also browse the directory directly from the application by adding `https://directory.owncast.online/api/iptv` to the application. Not all apps support this.
+If your application has _IPTV_ or _M3U_ support, you can also browse the directory directly from the application by adding `https://owncast.directory/api/iptv` to the application. Not all apps support this.
 
 ## Device and Platform support
 
@@ -108,7 +108,7 @@ iPlayTV
 
 1. Install [iPlayTV](https://apps.apple.com/us/app/iplaytv-iptv-m3u-player/id1072226801) from the tvOS App Store.
 1. Visit Settings -> Edit
-1. For the `M3U` Playlist URL: `https://directory.owncast.online/api/iptv`
+1. For the `M3U` Playlist URL: `https://owncast.directory/api/iptv`
 1. Change the `Channels Refresh` to the lowest value it offers.
 
 <a href="https://apps.apple.com/us/app/iplaytv-iptv-m3u-player/id1072226801">
@@ -132,7 +132,7 @@ iPlayTV
 
 1. Install **SATV** (free) from your smart TV's app store.
 1. Run it and press button to **"Add Playlist"**.
-1. Type in: `https://directory.owncast.online/api/iptv`. Make sure it's _https_.
+1. Type in: `https://owncast.directory/api/iptv`. Make sure it's _https_.
 1. Double check you typed it in correctly.
 1. Save this playlist.
 1. It will refresh the current live streams each time you launch the SATV app.

--- a/content/donated.md
+++ b/content/donated.md
@@ -24,7 +24,7 @@ Our resources are limited, and we'll be picky and start small. These servers wil
 
 ## What we would ask of you
 
-- Be listed as a public streamer on our [Directory](https://directory.owncast.online) where people would discover you.
+- Be listed as a public streamer on our [Directory](https://owncast.directory) where people would discover you.
 - Stream consistently enough to make it worthwhile for everyone involved, and that you expect to continue streaming into the future.
 - Plan on making an effort to build an audience.
 - Nothing NSFW or crazy offensive. As always, if you run your own server you can do whatever you like. But in this case we'll be responsible for the servers and they'll be shown to the general public, so we want the content to be generally accessible.

--- a/layouts/partials/footer/footer.html
+++ b/layouts/partials/footer/footer.html
@@ -3,7 +3,7 @@
     <li><a href="/about">About</a></li>
     <li><a href="/faq">FAQ</a></li>
     <li><a href="https://videos.owncast.online">Videos</a></li>
-    <li><a href="https://directory.owncast.online">Directory</a></li>
+    <li><a href="https://owncast.directory">Directory</a></li>
     <li><a href="https://merch.owncast.online">Merch Store</a></li>
     <li><a href="/newsletter">Newsletter</a></li>
     <li><a href="/roadmap">Roadmap</a></li>

--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -32,7 +32,7 @@
           </li>
         {{ end -}}
           <li class="nav-item">
-            <a class="nav-link" href="https://directory.owncast.online" target="_blank" rel="noopener noreferrer">Directory</a>
+            <a class="nav-link" href="https://owncast.directory" target="_blank" rel="noopener noreferrer">Directory</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="https://merch.owncast.online" target="_blank" rel="noopener noreferrer">Shop</a>


### PR DESCRIPTION
# Summary
This commit modifies 4 files to change "directory.owncast.online" to "owncast.directory" because "directory.owncast.online" redirects to "owncast.directory", so it's not nessacary.

# Notes
I did not modify the following files:

- [L13 of `assets/js/yp-livenow.js`](https://github.com/owncast/owncast.github.io/blob/master/assets/js/yp-livenow.js#L13): The `/api/active` endpoint has not migrated to `owncast.directory` yet, it is still using `directory.owncast.online`.
- [L45 of `assets/js/yp-livenow.js`](https://github.com/owncast/owncast.github.io/blob/master/assets/js/yp-livenow.js#L45): The `/api/image/thumb` endpoint has not migrated to `owncast.directory` yet, it is still using `directory.owncast.online`.
- [L57 of `content/releases/owncast-0.0.6.md`](https://github.com/owncast/owncast.github.io/blob/master/content/releases/owncast-0.0.6.md?plain=1#L57) - For historical/archival purposes.

<hr/>
If there is any more changes needed for this pull request to be merged, let me know and I will fix them!