### PR TITLE
docs(plugins): document namespaced emitted events

### DIFF
--- a/docs/plugins/apis.mdx
+++ b/docs/plugins/apis.mdx
@@ -585,6 +585,9 @@ Emit a custom event that other plugins can subscribe to. The host prefixes
 Pass an event-name suffix. Dots are allowed for hierarchy. Subscribers use the
 fully qualified `<plugin-slug>.<event>` name in their custom-event handler:
 see the [handlers reference](/docs/plugins/events#plugin-to-plugin-events).
+If the composed name would equal a built-in Owncast event (a plugin slugged
+`chat` emitting `message.received`), the host drops the emit instead of
+delivering a forged core event.
 
 <Tabs groupId="plugin-lang">
 <TabItem value="js" label="JavaScript" default>

--- a/docs/plugins/testing.mdx
+++ b/docs/plugins/testing.mdx
@@ -217,7 +217,7 @@ The scenario's top-level `expect` checks what happened across the whole run:
 | `bannedIPs`         | List of IPs banned via `owncast.users.banIP`                                                                                                                                                                                           |
 | `uploads`           | List of `{ name, body?, bodyBase64? }` from `owncast.storage.upload`. `name` is always checked. Non-empty `body` values compare text. Present `bodyBase64` values compare exact decoded bytes                                          |
 | `videoConfigWrites` | List of partial configs applied via `owncast.videoConfig.write()`                                                                                                                                                                      |
-| `emits`             | List of `{ eventType, payload }` for `owncast.events.emit` calls                                                                                                                                                                       |
+| `emits`             | List of `{ eventType, payload }` for `owncast.events.emit` calls. `eventType` is the dispatched name, so it carries your plugin's slug prefix                                                                                          |
 | `commands`          | List of `{ name, prefix?, description?, usage?, aliases?, modOnly, caseSensitive, cooldownMs }` chat-command registrations, matched by `name` in any order (`prefix`, `description`, `usage`, and `aliases` are checked only when set) |
 | `kv`                | Partial map of plugin-config state after the scenario                                                                                                                                                                                  |
 | `httpRequests`      | List of `{ url, method?, body? }` outbound `owncast.http.fetch` calls. `url` is an exact match, an omitted `method` matches any, an omitted `body` skips the check                                                                     |
@@ -274,7 +274,7 @@ Example exercising several:
   "expect": {
     "chatSends": ["alice: 1 message", "alice: 2 messages"],
     "kv": { "count:u-alice": "2" },
-    "emits": [{ "eventType": "milestone.reached", "payload": { "user": "alice", "count": 2 } }]
+    "emits": [{ "eventType": "my-plugin.milestone.reached", "payload": { "user": "alice", "count": 2 } }]
   }
 }
 ```


### PR DESCRIPTION
Documents the host-side custom event namespacing added in owncast/owncast#5117 (issue owncast/owncast#5093), matching owncast/plugin-sdk#15.

## Changes
- `apis.mdx`: note that the host drops an emitted name that, once prefixed with your slug, would equal a built-in event (a plugin slugged `chat` emitting `message.received`).
- `testing.mdx`: scenario `emits.eventType` is the dispatched name, so it carries the emitting plugin's slug prefix. Example expectation updated to `my-plugin.milestone.reached`.

The rest of the namespacing wording (`apis.mdx` emit description, `events.mdx`, `permissions.md`) is already on `owncast-docusaurus`. This PR only adds what those pages were missing.

Targets `owncast-docusaurus` because the plugin docs live on that branch, not on `master`.

## Merge order
This branch documents behavior that is not in a released Owncast yet, so it should publish only after a release carries owncast/owncast#5117. Until then a reader's `owncast-plugin test` run emits the unprefixed name and the `testing.mdx` example would not match. Note that the base branch already describes slug prefixing, so the same caveat applies to it independently of this PR.
